### PR TITLE
Added group description (italian)

### DIFF
--- a/docs/group_desc_ita.md
+++ b/docs/group_desc_ita.md
@@ -1,0 +1,21 @@
+Gli `Zencoders` sono un gruppo di software developers e appassionati di
+informatica che cooperano per realizzare progetti comuni o semplicemente per
+favorire la circolazione di idee.  
+Il gruppo `Zencoders` punta alla condivisione delle conoscenze, come mezzo
+principale al fine di per sviluppare idee innovative.
+
+Ogni membro del gruppo può partecipare a qualsiasi progetto ospitato nei
+repository open di `Zencoders` o avviare un nuovo progetto.  
+Gli zencoders non adottano né spingono verso una particolare tecnologia, ma il
+codice dei progetti resterà sempre *aperto* e rilasciato con licenze open [GPL and
+GPL-compatible, BSD, MIT, Apache, Mozilla, Eclipse, DTFYW].  
+Ne consegue che modifiche e contributi possono provenire (e sono benaccetti), da
+chiunque sia interessato al progetto, ma ogni progetto ha un ristretto numero di
+gestori facenti parte del gruppo `Zencoders`.
+Chiunque volesse contribuire regolarmente ad uno progetto `Zencoders` può chiedere
+l'accesso al gruppo, accettandone le regole, e il permesso all'attuale
+maintainer del progetto.
+
+Il gruppo è totalmente no-profit, non ci sono costi di iscrizione e gli unici
+profitti che provengono dalla affiliazione al gruppo sono da intendersi in
+termini di esperienza e visibilità.


### PR DESCRIPTION
Added group description in italian, that is a slightly changed
version of the one of zenconf_2014
